### PR TITLE
DPE-129 mysql router oci image

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Issue
+<!-- What does this PR solve? Include a Jira ticket.  -->
+
+## Solution
+<!-- A summary of the proposed solution to the above issue. -->
+
+## Context
+<!-- Necessary details to understand the proposed changes. -->
+
+## Release Notes
+<!-- A simple bullet-point summary of the changes in this PR. -->
+
+## Testing
+<!-- A summary of how this PR has been tested, including automated testing. -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS base
+FROM ubuntu:20.04
 
 ENV CONFIG_VERSION="0.8.22-1"
 
@@ -13,8 +13,6 @@ RUN apt-get update && \
     apt-get install -y mysql-shell\
         mysql-router && \
     rm -rf /var/lib/apt/lists/*
-
-FROM base AS runtime
 
 COPY run.sh /run.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:20.04 AS base
+
+ENV CONFIG_VERSION="0.8.22-1"
+
+RUN apt-get update && \
+    apt-get install -y wget \
+        lsb-release \
+        gnupg && \
+    wget -q https://dev.mysql.com/get/mysql-apt-config_${CONFIG_VERSION}_all.deb \
+        -O /tmp/mysql-apt-config_${CONFIG_VERSION}_all.deb && \
+    yes -4 | dpkg -i /tmp/mysql-apt-config_${CONFIG_VERSION}_all.deb && \
+    apt-get update && \
+    apt-get install -y mysql-shell\
+        mysql-router && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM base AS runtime
+
+COPY run.sh /run.sh
+
+CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ RUN apt-get update && \
 COPY run.sh /run.sh
 
 CMD ["/run.sh"]
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # mysql-router-container
+
+OCI image for MySQL Router operator.
+
+Built for usage in the [MySQL Router Charmed Operator for k8s](https://github.com/canonical/mysql-router-container).
+
+## Build
+
+```shell
+docker build -t mysql-router:latest .
+```
+
+## Run
+
+<!--TODO -->
+
+## Environment Variables
+
+<!--TODO -->

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sleep 3600

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 sleep 3600
+


### PR DESCRIPTION
## Issue

In short, [DPE-129](https://warthogs.atlassian.net/browse/DPE-129)
In long, this is the Dockerfile to create mysql-router application container.

## Solution

Dockerfile that installs mysql-shell and mysql-router, from ubuntu base image (focal).

## Context

We need a ubuntu based image for mysql-router (the official one is based on oracle-linux).

## Release Notes

* Add Dockerfile
* Add placeholder `run.sh` script

## Testing

Build and run with docker. The `run.sh` will enable the container to run for one hour before failing.
