### PR TITLE
Limit REST API to localhost

### DIFF
--- a/local/run.sh
+++ b/local/run.sh
@@ -62,7 +62,7 @@ EOF
       echo "Successfully contacted cluster with $MYSQL_INNODB_CLUSTER_MEMBERS members. Bootstrapping."
     fi
     echo "Succesfully contacted mysql server at $MYSQL_HOST. Trying to bootstrap."
-    mysqlrouter --bootstrap "$MYSQL_USER@$MYSQL_HOST:$MYSQL_PORT" --user=mysqlrouter --directory /tmp/mysqlrouter --force < "$PASSFILE"
+    mysqlrouter --bootstrap "$MYSQL_USER@$MYSQL_HOST:$MYSQL_PORT" --user=mysqlrouter --directory /tmp/mysqlrouter --conf-set-option=http_server.bind_address=127.0.0.1 --force < "$PASSFILE"
     sed -i -e 's/logging_folder=.*$/logging_folder=/' /tmp/mysqlrouter/mysqlrouter.conf
     echo "Starting mysql-router."
     exec "$@" --config /tmp/mysqlrouter/mysqlrouter.conf


### PR DESCRIPTION
## Issue
By default, the mysql router REST API listens on 0.0.0.0

[DPE-1327](https://warthogs.atlassian.net/browse/DPE-1327)

## Solution
Listen on 127.0.0.1 instead

[DPE-1327]: https://warthogs.atlassian.net/browse/DPE-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ